### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This addresses this issue in the PHP community.
 
 ## Content
 
-- [PSR-2-R](PSR-2-R-coding-style-guide.md) - "PSR-2 with tabs and consistent brace style" (= "CakePHP1+2 style")
+- [PSR-2-R](PSR-2-R-coding-style-guide.md) - "PSR-2 with tabs and consistent brace style"
 - [PSR-2-R Additions](PSR-2-R-coding-style-guide-additions.md) - optional coding standard recommendations
 - Reasoning behind it and a spaces-vs-tabs evaluation
 


### PR DESCRIPTION
Remove this. Better work with good arguments than references. If we list references we should list big frameworks and their versions and what they did different from PSR-x, not just one framework.
