### PR TITLE
Changed the required word to suggested in additions

### DIFF
--- a/PSR-2-R-coding-style-guide-additions.md
+++ b/PSR-2-R-coding-style-guide-additions.md
@@ -317,7 +317,7 @@ $this->doSomehing();
 Comment blocks, with the exception of the first block in a file, should always be preceded by a newline.
 
 ### Tags
-Suggested tags for each function/method are:
+Recommended tags for each function/method are:
 
 * `@param` if applicable
 * `@return`

--- a/PSR-2-R-coding-style-guide-additions.md
+++ b/PSR-2-R-coding-style-guide-additions.md
@@ -317,7 +317,7 @@ $this->doSomehing();
 Comment blocks, with the exception of the first block in a file, should always be preceded by a newline.
 
 ### Tags
-Required tags for each function/method are:
+Suggested tags for each function/method are:
 
 * `@param` if applicable
 * `@return`


### PR DESCRIPTION
Having a required word in something that is a suggestion/optional is a little bit inconcistent.